### PR TITLE
adds the DCML corpora that are currently public

### DIFF
--- a/DCML_corpora.ini
+++ b/DCML_corpora.ini
@@ -1,20 +1,68 @@
+[DCML]
+access: collection
+collection:
+    ABC
+    beethoven_piano_sonatas
+    chopin_mazurkas
+    corelli
+    debussy_suite_bergamasque
+    dvorak_silhouettes
+    grieg_lyric_pieces
+    liszt_pelerinage
+    medtner_tales
+    mozart_piano_sonatas
+    schumann_kinderszenen
+    tchaikovsky_seasons
+
+
 [ABC]
-access: git
-url: git@github.com:DCMLab/ABC.git
+access: zip
+url: https://github.com/DCMLab/ABC/archive/refs/heads/master.zip
 
-[ABC_labels]
-parent: ABC
-path: data/tsv
-file_regex: ^.*\.tsv$$
-file_type: tsv
-tsv_time: totbeat
-tsv_duration: length
+[beethoven_piano_sonatas]
+access: zip
+url: https://github.com/DCMLab/beethoven_piano_sonatas/archive/refs/heads/main.zip
 
-[ABC_scores]
-parent: ABC
-path: data/mscx
-file_regex: ^.*\.mscx$$
-file_type: mscx
+[chopin_mazurkas]
+access: zip
+url: https://github.com/DCMLab/chopin_mazurkas/archive/refs/heads/main.zip
+
+[corelli]
+access: zip
+url: https://github.com/DCMLab/corelli/archive/refs/heads/main.zip
+
+[debussy_suite_bergamasque]
+access: zip
+url: https://github.com/DCMLab/debussy_suite_bergamasque/archive/refs/heads/main.zip
+
+[dvorak_silhouettes]
+access: zip
+url: https://github.com/DCMLab/dvorak_silhouettes/archive/refs/heads/main.zip
+
+[grieg_lyric_pieces]
+access: zip
+url: https://github.com/DCMLab/grieg_lyric_pieces/archive/refs/heads/main.zip
+
+[liszt_pelerinage]
+access: zip
+url: https://github.com/DCMLab/liszt_pelerinage/archive/refs/heads/main.zip
+
+[medtner_tales]
+access: zip
+url: https://github.com/DCMLab/medtner_tales/archive/refs/heads/main.zip
+
+[mozart_piano_sonatas]
+access: zip
+url: https://github.com/DCMLab/mozart_piano_sonatas/archive/refs/heads/main.zip
+
+[schumann_kinderszenen]
+access: zip
+url: https://github.com/DCMLab/schumann_kinderszenen/archive/refs/heads/main.zip
+
+[tchaikovsky_seasons]
+access: zip
+url: https://github.com/DCMLab/tchaikovsky_seasons/archive/refs/heads/main.zip
+
 
 [iRealPro]
 access: git


### PR DESCRIPTION
adds the corpora that are currently public under https://github.com/DCMLab/dcml_corpora

What is the current state of the art of encoding the various data facets (notes, measures, labels, scores) that the corpora offer? Since they all share the same corpus structure now, is there a good way of encoding that only once?

Likewise, I was wondering if we could simply make the access method ``git`` and then have the library compute the URL of the latest zip file automatically if the main branch is defined additionally? That way, the user would gain the freedom of choice between cloning and simply downloading the latest version.